### PR TITLE
ai修复3个bug

### DIFF
--- a/Core/spider.py
+++ b/Core/spider.py
@@ -36,9 +36,11 @@ class Waiter():
                      "Spider", "timeout")),
                  stock_provider=config.settings(
                      "Spider", "stock_provider") or "page",
-                 date=config.settings('Spider', 'buy_time').__str__()
+                 date=config.settings('Spider', 'buy_time').__str__(),
+                 submit_order=False,
+                 **kwargs
                  ):
-
+        self.submit_order = submit_order
         self.skuids = skuids
         self.area = area
         self.eid = eid
@@ -284,7 +286,7 @@ class Waiter():
         self.status = "waiting"
         self.last_message = "正在等待设定时间"
         self.timers = Timer(self.buyTime)
-        self.timers.start()
+        self.timers.start(self)
         self.status = "running"
         self.last_message = "正在定时检查库存"
         for count in range(int(self.retry)):
@@ -321,7 +323,7 @@ class Waiter():
         self.status = "waiting"
         self.last_message = "正在等待设定时间"
         self.timers = Timer(self.buyTime)
-        self.timers.start()
+        self.timers.start(self)
         if self.stop_requested:
             self.status = "stopped"
             self.last_message = "定时下单已停止"

--- a/Core/timer.py
+++ b/Core/timer.py
@@ -18,7 +18,16 @@ class Timer(object):
         #    localtime.tm_year.__str__() + '-' + localtime.tm_mon.__str__() + '-' + localtime.tm_mday.__str__()
         #    + ' ' + buy_time_everyday,
         #    "%Y-%m-%d %H:%M:%S.%f")
-        self.buy_time = datetime.strptime(buy_time_everyday, "%Y-%m-%d %H:%M:%S.%f")
+        
+        # 这里修复了缩进，使其包含在 __init__ 方法内部
+        try:
+            self.buy_time = datetime.strptime(buy_time_everyday, "%Y-%m-%d %H:%M:%S.%f")
+        except ValueError:
+            try:
+                self.buy_time = datetime.strptime(buy_time_everyday, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                self.buy_time = datetime.strptime(buy_time_everyday, "%Y-%m-%d %H:%M")
+        
         self.buy_time_ms = int(time.mktime(self.buy_time.timetuple()) * 1000.0 + self.buy_time.microsecond / 1000)
         self.sleep_interval = sleep_interval
 
@@ -55,11 +64,16 @@ class Timer(object):
         """
         return self.local_time() - self.jd_time()
 
-    def start(self):
+    def start(self, waiter=None):
         logger.info('正在等待到达设定时间:{}'.format(self.buy_time))
         logger.info('本地时间与参考时间误差为【{}】毫秒'.format(self.diff_time))
 
         while True:
+            # 新增：每次循环检测是否在工作台上按下了停止按钮
+            if waiter and getattr(waiter, 'stop_requested', False):
+                logger.info('任务已被手动停止，结束等待')
+                break
+
             # 本地时间减去与京东的时间差，能够将时间误差提升到0.1秒附近
             # 具体精度依赖获取京东服务器时间的网络时间损耗
             if self.local_time() - self.diff_time >= self.buy_time_ms:
@@ -67,4 +81,3 @@ class Timer(object):
                 break
             else:
                 time.sleep(self.sleep_interval)
-


### PR DESCRIPTION
修复 Waiter 类传参遗漏引起的崩溃

问题： api.py 实例化 Waiter 时传入了 submit_order，但 spider.py 中的 Waiter.__init__ 漏接了该参数，导致抛出 TypeError: unexpected keyword argument。

修复： 在 Core/spider.py 的构造函数中补充了 submit_order=False 及 **kwargs，以兼容参数传递。

修复 Timer 定时任务的时间解析异常

问题： 前端页面下发的时间格式通常只有分（如 %Y-%m-%d %H:%M），而 timer.py 死板要求匹配到微秒（%Y-%m-%d %H:%M:%S.%f），导致 ValueError。

修复： 在 Core/timer.py 中增加了针对无毫秒和无秒格式时间的 try-except 兼容解析。

修复定时模式下“停止监控”按钮失效的问题

问题： 处于定时等待状态时，线程卡在 timer.py 的 while True 死循环里死等时间到达，忽略了前端发来的停止信号。

修复： 在 Core/timer.py 的等待循环中增加了对 waiter.stop_requested 标志位的检测；并在 Core/spider.py 调用 self.timers.start(self) 时将当前实例传过去，实现秒级中断。